### PR TITLE
Issue/14/besttype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # rail_bpz
-RAIL interface to BPZ algorithms
+RAIL interface to BPZ algorithms via the [DESC_BPZ](https://github.com/LSSTDESC/DESC_BPZ) package implementation (also available via PyPI with `pip install desc-bpz`).
+
+As the "lite" name implies, not all features of BPZ are implemented, the main product is the marginalized redshift PDF, which is output for a sample as a `qp` ensemble.  However, several other quantities are computed and stored as "ancillary" data and stored with the ensemble, these are:
+- zmode (float): the mode of the marginalized posterior redshift PDF distribution.
+- zmean (float): the mean of the marginalized posterior redshift PDF distribution.
+- tb (int): the integer index for the "best-fit" SED template **at the redshift mode, `zmode`**.  Note that the best-fit template can be different at different redshifts as the SED observed colors change with redshift, so you **can not** assume this single SED for the full marginalized PDF, it should only be used for the "point estimate" redshift `zmode`.
+- todds (float): relating to the comment above on tb, `todds` is a new quantity not included with the original BPZ implementation, it is the fraction of marginalized posterior probability assigned to `tb`.  So, high values of `todds` would mean that no other templates fit well, even at other redshifts, while a lower value of `todds` means that there are alternative fits, either at the same redshift or other redshifts.  If you are wanting to compute physical quantities based on `tb`, a lower value of `todds` would mean that such fits would be missing degenerate SED solutions, and should not be trusted.
+
+

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -26,7 +26,6 @@ import scipy.integrate
 import glob
 import qp
 import tables_io
-import rail
 from ceci.config import StageParameter as Param
 from rail.estimation.estimator import CatEstimator, CatInformer
 from rail.estimation.algos import bpz_version
@@ -246,7 +245,7 @@ class BPZ_lite(CatEstimator):
     tb: integer specifying the best-fit SED *at the redshift mode*
     todds: fraction of marginalized posterior prob. of best template,
     so lower numbers mean other templates could be better fits, likely
-    at other redshifts    
+    at other redshifts
     """
     name = "BPZ_lite"
     config_options = CatEstimator.config_options.copy()
@@ -317,7 +316,7 @@ class BPZ_lite(CatEstimator):
         # If we are not the root process then we wait for
         # the root to (potentially) create all the templates before
         # reading them ourselves.
-        if self.rank > 0: # pragma: no cover
+        if self.rank > 0:  # pragma: no cover
             # The Barrier method causes all processes to stop
             # until all the others have also reached the barrier.
             # If our rank is > 0 then we must be running under MPI.
@@ -332,9 +331,8 @@ class BPZ_lite(CatEstimator):
             # If we are running MPI, then now we have created
             # the templates we let all the other processes that
             # stopped at the Barrier above continue and read them.
-            if self.is_mpi(): # pragma: no cover
+            if self.is_mpi():  # pragma: no cover
                 self.comm.Barrier()
-
 
     def open_model(self, **kwargs):
         CatEstimator.open_model(self, **kwargs)
@@ -514,7 +512,6 @@ class BPZ_lite(CatEstimator):
         # relative to the other templates
         tmarg = post.sum(axis=0)
         todds = tmarg[t_b] / np.sum(tmarg)
-                           
 
         return post_z, zmode, t_b, todds
 


### PR DESCRIPTION
A fairly small and straightforward PR that adds back in calculation of "tb" the best-fit type at the redshift mode, as well as a new quantity I made up, `todds`, the fraction of marginalized posterior probability in `tb` vs all types (so a measure of how probable the galaxy is to be of type tb at all redshifts vs some other SED).  These should be useful for type and physical parameter studies that have been mentioned recently.  