### PR TITLE
naming consistency/clarity within src/rail/estimation

### DIFF
--- a/examples/BPZ_lite_demo.ipynb
+++ b/examples/BPZ_lite_demo.ipynb
@@ -30,7 +30,7 @@
     "from rail.core.data import TableHandle\n",
     "from rail.core.stage import RailStage\n",
     "from rail.core.utils import RAILDIR\n",
-    "from rail.estimation.algos.bpz_lite import Inform_BPZ_lite, BPZ_lite"
+    "from rail.estimation.algos.bpz_lite import BPZliteInformer, BPZliteEstimator"
    ]
   },
   {
@@ -88,12 +88,12 @@
    "id": "979d5363-af4e-4478-9820-29214292bf16",
    "metadata": {},
    "source": [
-    "## running BPZ_lite with a pre-existing model\n",
+    "## running BPZliteEstimator with a pre-existing model\n",
     "\n",
-    "BPZ is a template-fitting code that works by calculating the chi^2 value for observed photometry and errors compared with a grid of theoretical photometric fluxes generated from a set of template SEDs at each of a grid of redshift values.  These chi^2 values are converted to likelihoods.  If desired, a Bayesian prior can be applied that parameterizes the expected distribution of galaxies in terms of both probability of a \"broad\" SED type as a function of apparent magnitude, and the probability of a galaxy being at a certain redshift given broad SED type and apparent magnitude.  The product of this prior and the likelihoods is then summed over the SED types to return a marginalized posterior PDF, or p(z) for each galaxy.  If the config option `no_prior` is set to `True`, then no prior is applied, and BPZ_lite will return a likelihood for each galaxy rather than a posterior.\n",
+    "BPZ is a template-fitting code that works by calculating the chi^2 value for observed photometry and errors compared with a grid of theoretical photometric fluxes generated from a set of template SEDs at each of a grid of redshift values.  These chi^2 values are converted to likelihoods.  If desired, a Bayesian prior can be applied that parameterizes the expected distribution of galaxies in terms of both probability of a \"broad\" SED type as a function of apparent magnitude, and the probability of a galaxy being at a certain redshift given broad SED type and apparent magnitude.  The product of this prior and the likelihoods is then summed over the SED types to return a marginalized posterior PDF, or p(z) for each galaxy.  If the config option `no_prior` is set to `True`, then no prior is applied, and BPZliteEstimator will return a likelihood for each galaxy rather than a posterior.\n",
     "\n",
     "\n",
-    "`bpz-1.99.3`, the code written by Dan Coe and Narcisso Benitez and available at https://www.stsci.edu/~dcoe/BPZ/, uses a default set of eight SED templates: four templates from Coleman, Wu, & Weedman (CWW, one Elliptical, two Spirals Sbc and Scd, and one Irregular), two starburst (WB) templates, and two very blue star forming templates generated using Bruzual & Charlot models with very young ages of 25Myr and 5Myr.  The original BPZ paper, Benitez(2000) computed a \"default\" prior fit to data from the Hubble Deep Field North (HDFN).  A pickle file with these parameters and the default SEDs are included with RAIL, named `CWW_HDFN_prior.pkl`.  You can run BPZ_lite with these default templates and priors without doing any training, the equivalent of \"running BPZ with the defaults\" had you downloaded bpz-1.99.3 and run it.  **Note, however**, that the cosmoDC2_v1.1.4 dataset has a population of galaxy SEDs that are fairly different from the \"default\" CWWSB templates, and the prior distributions do not exactly match.  So, you will get results that do not look particularly good.  We will demonstrate that use case here, though, as it is the most simple way to run the code out of the box (and illustrates the dangers of grabbing code and running it out of the box):\n",
+    "`bpz-1.99.3`, the code written by Dan Coe and Narcisso Benitez and available at https://www.stsci.edu/~dcoe/BPZ/, uses a default set of eight SED templates: four templates from Coleman, Wu, & Weedman (CWW, one Elliptical, two Spirals Sbc and Scd, and one Irregular), two starburst (WB) templates, and two very blue star forming templates generated using Bruzual & Charlot models with very young ages of 25Myr and 5Myr.  The original BPZ paper, Benitez(2000) computed a \"default\" prior fit to data from the Hubble Deep Field North (HDFN).  A pickle file with these parameters and the default SEDs are included with RAIL, named `CWW_HDFN_prior.pkl`.  You can run BPZliteEstimator with these default templates and priors without doing any training, the equivalent of \"running BPZ with the defaults\" had you downloaded bpz-1.99.3 and run it.  **Note, however**, that the cosmoDC2_v1.1.4 dataset has a population of galaxy SEDs that are fairly different from the \"default\" CWWSB templates, and the prior distributions do not exactly match.  So, you will get results that do not look particularly good.  We will demonstrate that use case here, though, as it is the most simple way to run the code out of the box (and illustrates the dangers of grabbing code and running it out of the box):\n",
     "\n",
     "We need to set up a RAIL stage for the default run of BPZ, including specifying the location of the model pickle file:"
    ]
@@ -108,7 +108,7 @@
     "hdfnfile = os.path.join(RAILDIR, \"rail/examples_data/estimation_data/data/CWW_HDFN_prior.pkl\")\n",
     "default_dict = dict(hdf5_groupname=\"photometry\", output=\"bpz_results_defaultprior.hdf5\",\n",
     "                    prior_band=\"mag_i_lsst\", no_prior=False)\n",
-    "run_default = BPZ_lite.make_stage(name=\"bpz_def_prior\", model=hdfnfile, **default_dict)"
+    "run_default = BPZliteEstimator.make_stage(name=\"bpz_def_prior\", model=hdfnfile, **default_dict)"
    ]
   },
   {
@@ -116,7 +116,7 @@
    "id": "e8bba83c-d3ed-4385-852c-639e59170c48",
    "metadata": {},
    "source": [
-    "Let's run the estimate stage, if this is the first run of ``BPZ_lite`` or ``Inform_BPZ_lite``, you may see a bunch of output lines as ``DESC_BPZ`` creates the synthetic photometry \"AB\" files for the SEDs and filters."
+    "Let's run the estimate stage, if this is the first run of ``BPZliteEstimator`` or ``BPZliteInformer``, you may see a bunch of output lines as ``DESC_BPZ`` creates the synthetic photometry \"AB\" files for the SEDs and filters."
    ]
   },
   {
@@ -179,7 +179,7 @@
    "source": [
     "Results do not look bad, there are some catastrophic outliers, and there appears to be some bias in the redshift estimates, but as the SED templates have slightly systematically different colors than our test data, that is just what we expect to see.\n",
     "\n",
-    "BPZ_lite also produces a `tb` , a \"best-fit type\"; that is, the SED template with the highest posterior probability contribution at the value of the `zmode`. We can plot up a color color diagram of our test data and we should see a pattern in color space reflecting the different populations in different areas of color space.  `tb` is stored as an 1-indexed integer corresponding the the number of the SED in our template set."
+    "BPZliteEstimator also produces a `tb` , a \"best-fit type\"; that is, the SED template with the highest posterior probability contribution at the value of the `zmode`. We can plot up a color color diagram of our test data and we should see a pattern in color space reflecting the different populations in different areas of color space.  `tb` is stored as an 1-indexed integer corresponding the the number of the SED in our template set."
    ]
   },
   {
@@ -231,7 +231,7 @@
    "id": "6ee27ab8-2282-45ae-99bc-a8fcc5691ee1",
    "metadata": {},
    "source": [
-    "BPZ_lite also computes a quantity called `todds`, which is the fraction of posterior probability in the best-fit SED relative to the overall probability of all templates.  If the value is high, then a single SED is providing more of the probability.  If the value is low, then multiple SEDs are contributing, which means that `tb`, the best-fit-SED-type, is less meaningful.  The values of todds whould be lower where SEDs have degenerate broad-band colors, let's highlight the values of low todds and see where they lie in color space."
+    "BPZliteEstimator also computes a quantity called `todds`, which is the fraction of posterior probability in the best-fit SED relative to the overall probability of all templates.  If the value is high, then a single SED is providing more of the probability.  If the value is low, then multiple SEDs are contributing, which means that `tb`, the best-fit-SED-type, is less meaningful.  The values of todds whould be lower where SEDs have degenerate broad-band colors, let's highlight the values of low todds and see where they lie in color space."
    ]
   },
   {
@@ -264,15 +264,15 @@
    "id": "e80d59ce-ca73-4bf3-9f3d-682c4dbdcb3e",
    "metadata": {},
    "source": [
-    "# Inform_BPZ_lite: training a custom prior\n",
+    "# BPZliteInformer: training a custom prior\n",
     "\n",
-    "If you want to go beyond the default prior, there is an `Inform_BPZ_lite` stage that allows you to use a training dataset to fit a custom parameterized prior that better matches the magnitude and type distributions of the training set.\n",
+    "If you want to go beyond the default prior, there is an `BPZliteInformer` stage that allows you to use a training dataset to fit a custom parameterized prior that better matches the magnitude and type distributions of the training set.\n",
     "\n",
-    "`bpz-1.99.3` and our local fork, `DESC_BPZ` both parameterize the Bayesian prior using the form described in Benitez (2000), where the individual SED types are grouped into \"broad types\", e.g. 1 Elliptical makes up one type, the two spirals (Sbc and Scd) make up a second, and the five remaining \"blue\" templates (Im, SB3, SB2, ssp25Myr, and ssp5Myr) make up a third type.  This grouping is somewhat ad-hoc, but does have physical motivation, in that we have observed that Ellipticals, spirals, and irregular/starburst galaxies do show distinctly evolving observed fractions as a function of apparent/absolute magnitude and redshift.  Things get more complicated with more complex SED sets that contain variations in dust content, star formation histories, emission lines, etc...  Due to such complications, the **current** implementation of `inform_BPZ_lite` leaves the assignment of a \"broad-SED-type\" to the user, and these broad types are a necessary input to `Inform_BPZ_lite` via the `type_file` config option.  In the future, determination of broad SED type will be added as a pre-processing step to the rail_bpz package.\n",
+    "`bpz-1.99.3` and our local fork, `DESC_BPZ` both parameterize the Bayesian prior using the form described in Benitez (2000), where the individual SED types are grouped into \"broad types\", e.g. 1 Elliptical makes up one type, the two spirals (Sbc and Scd) make up a second, and the five remaining \"blue\" templates (Im, SB3, SB2, ssp25Myr, and ssp5Myr) make up a third type.  This grouping is somewhat ad-hoc, but does have physical motivation, in that we have observed that Ellipticals, spirals, and irregular/starburst galaxies do show distinctly evolving observed fractions as a function of apparent/absolute magnitude and redshift.  Things get more complicated with more complex SED sets that contain variations in dust content, star formation histories, emission lines, etc...  Due to such complications, the **current** implementation of `BPZliteInformer` leaves the assignment of a \"broad-SED-type\" to the user, and these broad types are a necessary input to `BPZliteInformer` via the `type_file` config option.  In the future, determination of broad SED type will be added as a pre-processing step to the rail_bpz package.\n",
     "\n",
     "The easiest way to obtain these broad SED types is to run `DESC_BPZ` with the parameter `ONLY_TYPE` set to `yes`.  When the `ONLY_TYPE` option is turned on in `DESC_BPZ`, the code returns a best-fit SED type evaluated only at the spectroscopic redshift for the object (determined as the best chi^2 amongst the N templates).  The user then needs to map these N integers down to a set of \"broad-type\" integers corresponding to however they wish to define the mapping from N SED types to M broad types.  As an example, I have done this using the CWWSB templates and the 1 Ell, 2 sp, 5 Im/SB broad type mapping for our `test_dc2_training_9816.hdf5` dataset and included that mapping file in this directory in a file named `test_dc2_training_9816_broadtypes.hdf5` for use in our demo, which consists of an array of integers named `types` with values 0 (Elliptical), 1 (Spiral), and 2 (Irregular/Starburst) corresponding to the best-fit broad SED for each of the 10,225 galaxies in our training sample.\n",
     "\n",
-    "Now, let's set up our inform stage to calculate a new prior.  We will name the new prior `test_9816_demo_prior.pkl`, setting this as the `model` config parameter will tell `Inform_BPZ_lite` to save our trained model by that name in the current directory.\n",
+    "Now, let's set up our inform stage to calculate a new prior.  We will name the new prior `test_9816_demo_prior.pkl`, setting this as the `model` config parameter will tell `BPZliteInformer` to save our trained model by that name in the current directory.\n",
     "\n",
     "When we run `inform` it will display values for the parameters as the minimizer runs, including final values for the parameters.  You do not need to pay attention to these values, though if you are curious you can plot them up and compare to the distributions of the HDFN prior."
    ]
@@ -287,7 +287,7 @@
     "train_dict = dict(hdf5_groupname=\"photometry\", model=\"test_9816_demo_prior.pkl\",\n",
     "                 type_file=\"test_dc2_training_9816_broadtypes.hdf5\",\n",
     "                 nt_array=[1,2,5])\n",
-    "run_bpz_train = Inform_BPZ_lite.make_stage(name=\"bpz_new_prior\", **train_dict)"
+    "run_bpz_train = BPZliteInformer.make_stage(name=\"bpz_new_prior\", **train_dict)"
    ]
   },
   {
@@ -420,7 +420,7 @@
    "id": "82d0919d-5842-4297-9a03-3838c6be6a2c",
    "metadata": {},
    "source": [
-    "Now, let's re-run BPZ_lite using this new prior and see if our results are any different:"
+    "Now, let's re-run BPZliteEstimator using this new prior and see if our results are any different:"
    ]
   },
   {
@@ -432,7 +432,7 @@
    "source": [
     "rerun_dict = dict(hdf5_groupname=\"photometry\", output=\"bpz_results_rerun.hdf5\", prior_band='mag_i_lsst',\n",
     "                 no_prior=False)\n",
-    "rerun = BPZ_lite.make_stage(name=\"rerun_bpz\", **rerun_dict, \n",
+    "rerun = BPZliteEstimator.make_stage(name=\"rerun_bpz\", **rerun_dict, \n",
     "                            model=run_bpz_train.get_handle('model'))"
    ]
   },

--- a/examples/BPZ_lite_with_custom_SEDs.ipynb
+++ b/examples/BPZ_lite_with_custom_SEDs.ipynb
@@ -58,7 +58,7 @@
    "id": "a0d9bdc4-6022-4668-b003-686489e13ccd",
    "metadata": {},
    "source": [
-    "This should have successfully copied the files to the proper SED directory. Now, we can proceed in the same manner that we did in the `BPZliteEstimator_demo.ipynb` notebook:"
+    "This should have successfully copied the files to the proper SED directory. Now, we can proceed in the same manner that we did in the `BPZ_lite_demo.ipynb` notebook:"
    ]
   },
   {
@@ -551,7 +551,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/examples/BPZ_lite_with_custom_SEDs.ipynb
+++ b/examples/BPZ_lite_with_custom_SEDs.ipynb
@@ -5,7 +5,7 @@
    "id": "85906442-6d29-407a-8d80-4108d45af015",
    "metadata": {},
    "source": [
-    "# Running BPZ_lite with a custom set of SEDs\n",
+    "# Running BPZliteEstimator with a custom set of SEDs\n",
     "authors: Sam Schmidt<br>\n",
     "Last successfully run: Apr 14, 2023<br>\n",
     "\n",
@@ -58,7 +58,7 @@
    "id": "a0d9bdc4-6022-4668-b003-686489e13ccd",
    "metadata": {},
    "source": [
-    "This should have successfully copied the files to the proper SED directory. Now, we can proceed in the same manner that we did in the `BPZ_lite_demo.ipynb` notebook:"
+    "This should have successfully copied the files to the proper SED directory. Now, we can proceed in the same manner that we did in the `BPZliteEstimator_demo.ipynb` notebook:"
    ]
   },
   {
@@ -77,7 +77,7 @@
     "import desc_bpz\n",
     "from rail.core.data import TableHandle\n",
     "from rail.core.stage import RailStage\n",
-    "from rail.estimation.algos.bpz_lite import Inform_BPZ_lite, BPZ_lite"
+    "from rail.estimation.algos.bpz_lite import BPZliteInformer, BPZliteEstimator"
    ]
   },
   {
@@ -125,9 +125,9 @@
    "id": "e80d59ce-ca73-4bf3-9f3d-682c4dbdcb3e",
    "metadata": {},
    "source": [
-    "# Inform_BPZ_lite: training a custom prior with our new SEDs\n",
+    "# BPZliteInformer: training a custom prior with our new SEDs\n",
     "\n",
-    "We will run the inform stage just as we did in the main demo notebook; however, we will have to define a few extra configuration parameters in order to tell Inform_BPZ_lite to use our new SEDs.  We specify the SED set using the `spectra_file` configuration parameter, which points to an ascii file that contains the names of the SEDs, which must be sorted in the same order as the \"broad type array\" (usually done in ascending rest-frame \"blueness\", that is Elliptical red galaxies first, then increasingly blue galaxies). In this case, the tar file that we copied to the SED directory contained this file, named `baddc2templates.list`.   As before, we need a \"best fit type\" for each of the galaxies in our training set. And, as before, this has been computed separately (computing best type within rail_bpz will be added in the future).  The best fit broad types are available in a dictionary stored in the file `test_dc2_train_customtemp_broadttypes.hdf5`, which we will point to with the `type_file` config parameter.  This file should already exist in this directory.  As stated above, we have two Elliptical, three Spiral, and four Irregular/Starburst seds, so we'll set the `nt_array` configuration parameter to a list `[2, 3, 4]` to specify those numbers of the three broad types."
+    "We will run the inform stage just as we did in the main demo notebook; however, we will have to define a few extra configuration parameters in order to tell BPZliteInformer to use our new SEDs.  We specify the SED set using the `spectra_file` configuration parameter, which points to an ascii file that contains the names of the SEDs, which must be sorted in the same order as the \"broad type array\" (usually done in ascending rest-frame \"blueness\", that is Elliptical red galaxies first, then increasingly blue galaxies). In this case, the tar file that we copied to the SED directory contained this file, named `baddc2templates.list`.   As before, we need a \"best fit type\" for each of the galaxies in our training set. And, as before, this has been computed separately (computing best type within rail_bpz will be added in the future).  The best fit broad types are available in a dictionary stored in the file `test_dc2_train_customtemp_broadttypes.hdf5`, which we will point to with the `type_file` config parameter.  This file should already exist in this directory.  As stated above, we have two Elliptical, three Spiral, and four Irregular/Starburst seds, so we'll set the `nt_array` configuration parameter to a list `[2, 3, 4]` to specify those numbers of the three broad types."
    ]
   },
   {
@@ -142,7 +142,7 @@
     "                  type_file=\"test_dc2_train_customtemp_broadttypes.hdf5\",\n",
     "                  prior_band=\"mag_i_lsst\",\n",
     "                  nt_array=[2,3,4])\n",
-    "run_bpz_train = Inform_BPZ_lite.make_stage(name=\"bpz_custom_sed_prior\", **train_dict)"
+    "run_bpz_train = BPZliteInformer.make_stage(name=\"bpz_custom_sed_prior\", **train_dict)"
    ]
   },
   {
@@ -273,7 +273,7 @@
    "id": "82d0919d-5842-4297-9a03-3838c6be6a2c",
    "metadata": {},
    "source": [
-    "Now, let's re-run BPZ_lite using this new prior and see if our results are any different:"
+    "Now, let's re-run BPZliteEstimator using this new prior and see if our results are any different:"
    ]
   },
   {
@@ -289,7 +289,7 @@
     "                   prior_band='mag_i_lsst',\n",
     "                   data_path=custom_data_path,\n",
     "                   no_prior=False)\n",
-    "custom_run = BPZ_lite.make_stage(name=\"rerun_bpz\", **custom_dict, \n",
+    "custom_run = BPZliteEstimator.make_stage(name=\"rerun_bpz\", **custom_dict, \n",
     "                                 model=run_bpz_train.get_handle('model'))"
    ]
   },

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -40,8 +40,8 @@ def nzfunc(z, z0, alpha, km, m, m0):  # pragma: no cover
     return np.power(z, alpha) * np.exp(-1. * np.power((z / zm), alpha))
 
 
-class Inform_BPZ_lite(CatInformer):
-    """Inform stage for BPZ_lite, this stage *assumes* that you have a set of
+class BPZliteInformer(CatInformer):
+    """Inform stage for BPZliteEstimator, this stage *assumes* that you have a set of
     SED templates and that the training data has already been assigned a
     'best fit broad type' (that is, something like ellliptical, spiral,
     irregular, or starburst, similar to how the six SEDs in the CWW/SB set
@@ -61,7 +61,7 @@ class Inform_BPZ_lite(CatInformer):
     z0, km, and a for each type.  These parameters are then fed to the BPZ
     prior for use in the estimation stage.
     """
-    name = "Inform_BPZ_lite"
+    name = "BPZliteInformer"
     config_options = CatInformer.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,
@@ -232,7 +232,7 @@ class Inform_BPZ_lite(CatInformer):
         self.add_data("model", self.model)
 
 
-class BPZ_lite(CatEstimator):
+class BPZliteEstimator(CatEstimator):
     """CatEstimator subclass to implement basic marginalized PDF for BPZ
     In addition to the marginalized redshift PDF, we also compute several
     ancillary quantities that will be stored in the ensemble ancil data:
@@ -243,7 +243,7 @@ class BPZ_lite(CatEstimator):
     so lower numbers mean other templates could be better fits, likely
     at other redshifts
     """
-    name = "BPZ_lite"
+    name = "BPZliteEstimator"
     config_options = CatEstimator.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -39,7 +39,7 @@ def test_bpz_train(ntarray):
         broad_types = np.zeros(100, dtype=int)
     typedict = dict(types=broad_types)
     tables_io.write(typedict, "tmp_broad_types.hdf5")
-    train_algo = bpz_lite.Inform_BPZ_lite
+    train_algo = bpz_lite.BPZliteInformer
     DS.clear()
     training_data = DS.read_file('training_data', TableHandle, traindata)
     train_stage = train_algo.make_stage(**train_config_dict)
@@ -73,7 +73,7 @@ def test_bpz_lite():
                          'model': 'testmodel_bpz.pkl'}
     zb_expected = np.array([0.16, 0.12, 0.14, 0.14, 0.06, 0.14, 0.12, 0.14, 0.06, 0.16])
     train_algo = None
-    pz_algo = bpz_lite.BPZ_lite
+    pz_algo = bpz_lite.BPZliteEstimator
     results, rerun_results, rerun3_results = one_algo("BPZ_lite", train_algo, pz_algo, train_config_dict, estim_config_dict)
     assert np.isclose(results.ancil['zmode'], zb_expected).all()
     assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
@@ -106,7 +106,7 @@ def test_bpz_wHDFN_prior(inputdata, groupname):
                             2.98, 2.92])
 
     validation_data = DS.read_file('validation_data', TableHandle, inputdata)
-    pz = bpz_lite.BPZ_lite.make_stage(name='bpz_hdfn', **estim_config_dict)
+    pz = bpz_lite.BPZliteEstimator.make_stage(name='bpz_hdfn', **estim_config_dict)
     results = pz.estimate(validation_data)
     assert np.isclose(results.data.ancil['zmode'], zb_expected).all()
     DS.clear()
@@ -132,7 +132,7 @@ def test_bpz_lite_wkernel_flatprior():
     # zb_expected = np.array([0.18, 2.88, 0.12, 0.15, 2.97, 2.78, 0.11, 0.19,
     #                         2.98, 2.92])
     train_algo = None
-    pz_algo = bpz_lite.BPZ_lite
+    pz_algo = bpz_lite.BPZliteEstimator
     results, rerun_results, rerun3_results = one_algo("BPZ_lite", train_algo, pz_algo, train_config_dict, estim_config_dict)
     # assert np.isclose(results.ancil['zmode'], zb_expected).all()
     assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()


### PR DESCRIPTION
## Change Description

This PR (and other concurrent PRs in the other repos) include renamings of modules and stages within `src/rail/estimation` for consistency and transparency to users as outlined in LSSTDESC/rail#37. (Expect a few more PRs to address the smaller set of necessary consistency/clarity changes outside `src/rail/estimation` using the same branch.) 

- [x] My PR includes a link to the issue that I am addressing

I request that multiple reviewers please do not hesitate to suggest changes as needed! The goals are consistency, clarity, and longevity, so if something looks unclear, inconsistent, or insufficiently flexible to accommodate future development, now is the time to make adjustments.

## Solution Description

The following changes were made across all the rail repos, along with updates to the contributing documentation (which should be propagated to the rail python project template so prompts regarding naming are included in future PR checklists).

```
files:
  delightPZ.py --> delight_hybrid.py
  GPz.py --> _gpz_util.py
  knnpz.py --> k_nearneigh.py
  naiveStack.py --> naive_stack.py
  NZDir.py --> nz_dir.py
  pointEstimateHist.py --> point_est_hist.py
  pzflow.py --> pzflow_nf.py
  randomPZ.py --> random_gauss.py
  simpleSOM.py --> minisom_som.py
  sklearn_nn.py --> skl_neurnet.py
  somocluSOM.py --> somoclu_som.py
  trainZ.py --> train_z.py
  varInference.py --> var_inf.py
classes:
  Inform_BPZ_lite --> BPZliteInformer
  BPZ_lite --> BPZliteEstimator
  Inform_CMNNPDF --> CMNNInformer
  CMNNPDF --> CMNNEstimator
  Inform_DelightPZ --> DelightInformer
  delightPZ --> DelightEstimator  
  Inform_GPz_v1 --> GPzInformer
  GPz_v1 --> GPzEstimator
  Inform_FZBoost --> FlexZBoostInformer
  FZBoost --> FlexZBoostEstimator
  Inform_KNearNeighPDF --> KNearNeighInformer
  KNearNeighPDF --> KNearNeighEstimator
  NaiveStack --> NaiveStackSummarizer
  NZDir --> NZDirSummarizer  
  Inform_NZDir --> NZDirInformer
  PointEstimateHist --> PointEstHistSummarizer
  Inform_PZFlowPDF --> PZFlowInformer
  PZFlowPDF --> PZFlowEstimator
  RandomPZ --> RandomGaussEstimator
  Inform_SimpleNN --> SklNeurNetInformer
  SimpleNN --> SklNeurNetEstimator
  Inform_SimpleSOMSummarizer --> MiniSOMInformer
  SimpleSOMSummarizer --> MiniSOMSummarizer
  Inform_somocluSOMSummarizer --> SOMocluInformer
  somocluSOMSummarizer --> SOMocluSummarizer
  Inform_trainZ --> TrainZInformer
  TrainZ --> TrainZEstimator
  VarInferenceStack --> VarInfStackSummarizer   
```

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [X] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

Given that we are still pre-v1, I have not explicitly included backward compatibility, but a block of `import X as Y` can be constructed from the above list of changes.

### Other Change Checklist
- [X] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have updated unit/End-to-End (E2E) test cases to cover any changes

I fixed some instances of outdated descriptions in the demo notebooks, but others require more substantial editing, e.g. when they describe code that has long since been removed from the demo in question or aspects of the API that have significantly changed since the descriptions were written. The demos require a thorough review before v1 that's out of scope for this series of PRs.