### PR TITLE
Change `tools.setuptools` to `tool.setuptools`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ write_to = "src/rail/bpz/_version.py"
 "rail.examples.estimation.configs" = ["*.columns"]
 
 [tool.setuptools.packages.find]
-where = ["."]
+where = ["src"]
 include = ["rail"]
 namespaces = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ write_to = "src/rail/bpz/_version.py"
 [tool.setuptools.package-data]
 "rail.examples.estimation.configs" = ["*.columns"]
 
-[tools.setuptools.packages.find]
+[tool.setuptools.packages.find]
 where = ["."]
 include = ["rail"]
 namespaces = true


### PR DESCRIPTION
## Change Description
Fixing a typo in pyproject.toml. It's likely that this wasn't having an impact on the build, but it's not clear that it wouldn't affect it at some later time. 
