### PR TITLE
Download tarfile from NERSC

### DIFF
--- a/examples/BPZ_lite_with_custom_SEDs.ipynb
+++ b/examples/BPZ_lite_with_custom_SEDs.ipynb
@@ -21,8 +21,32 @@
    "id": "f6adf3d9-0f22-49d5-bc79-f40af8b294a3",
    "metadata": {},
    "source": [
-    "## action needed before running the notebook:\n",
-    "\n",
+    "## action needed before running the notebook:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c7e49d7",
+   "metadata": {},
+   "source": [
+    "To download the tarfile from NERSC, **uncomment the cell below and execute it**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfe0cdbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!rail get-data --bpz-demo-data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9a7463d",
+   "metadata": {},
+   "source": [
     "To actually untar and copy the files, **uncomment the lines in the cell below and execute the cell**"
    ]
   },
@@ -37,8 +61,12 @@
     "import os\n",
     "custom_data_path = RAILDIR + '/rail/examples_data/estimation_data/data'\n",
     "sedpath = RAILDIR + '/rail/examples_data/estimation_data/data/SED'\n",
-    "#os.environ['tempbpzsedpath'] = sedpath\n",
-    "#!tar -xvf nonphysical_dc2_templates.tar\n",
+    "tarpath = RAILDIR + '/rail/examples_data/estimation_data/data/nonphysical_dc2_templates.tar'\n",
+    "\n",
+    "os.environ['tempbpzsedpath'] = sedpath\n",
+    "os.environ['tempbpztarpath'] = tarpath\n",
+    "\n",
+    "#!tar -xvf $tempbpztarpath\n",
     "#!mv DC2_DONOTUSE*.sed $tempbpzsedpath\n",
     "#!mv baddc2templates.list $tempbpzsedpath"
    ]
@@ -525,14 +553,6 @@
    "source": [
     "Yes, in our one example PDF, number 109, we see almost no peak at high redshift, but rather a new peak at z~0.6, again demonstrating just how large of an impact the SED template set used has on photo-z results."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3a86e660-0bf5-4bd6-b9aa-27bc94f3b8e4",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -551,7 +571,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/BPZ_lite_with_custom_SEDs.ipynb
+++ b/examples/BPZ_lite_with_custom_SEDs.ipynb
@@ -63,9 +63,8 @@
     "sedpath = RAILDIR + '/rail/examples_data/estimation_data/data/SED'\n",
     "tarpath = RAILDIR + '/rail/examples_data/estimation_data/data/nonphysical_dc2_templates.tar'\n",
     "\n",
-    "os.environ['tempbpzsedpath'] = sedpath\n",
-    "os.environ['tempbpztarpath'] = tarpath\n",
-    "\n",
+    "#os.environ['tempbpzsedpath'] = sedpath\n",
+    "#os.environ['tempbpztarpath'] = tarpath\n",
     "#!tar -xvf $tempbpztarpath\n",
     "#!mv DC2_DONOTUSE*.sed $tempbpzsedpath\n",
     "#!mv baddc2templates.list $tempbpzsedpath"


### PR DESCRIPTION
PR made in preparation of moving the examples into the umbrella notebook (as part of rail [#48](https://github.com/LSSTDESC/rail/issues/48))

This places the tarfile on NERSC and downloads it with `rail get-data --bpz-demo-data` (cli option added in rail_base [#55](https://github.com/LSSTDESC/rail_base/pull/55)), before the existing code to untar and move the files. 

(Paths were also shifted a bit because we now download the tar directly into a RAILDIR + "rail/..." path.)