### PR TITLE
add check of f0 sum, norm if >1 #45

### DIFF
--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -138,7 +138,13 @@ class BPZliteInformer(CatInformer):
             self.fo_arr = np.array([frac_results[0]])
             self.kt_arr = np.array([frac_results[1]])
         else:
-            self.fo_arr = frac_results[:self.ntyp - 1]
+            tmpfo = frac_results[:self.ntyp - 1]
+            # minimizer can sometimes give fractions greater than one, if so normalize
+            fracnorm = np.sum(tmpfo)
+            if fracnorm > 1.:
+                print("bad norm for f0, normalizing")
+                tmpfo /= fracnorm
+            self.fo_arr = tmpfo
             self.kt_arr = frac_results[self.ntyp - 1:]
 
     def _dndz_likelihood(self, params):

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -141,7 +141,7 @@ class BPZliteInformer(CatInformer):
             tmpfo = frac_results[:self.ntyp - 1]
             # minimizer can sometimes give fractions greater than one, if so normalize
             fracnorm = np.sum(tmpfo)
-            if fracnorm > 1.:
+            if fracnorm > 1.:  # pragma: no cover
                 print("bad norm for f0, normalizing")
                 tmpfo /= fracnorm
             self.fo_arr = tmpfo


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Addresses the problem in issue #45 where the fractions f0 can sum to more than 1, which will force the last type to go negative at the m0 value and nearby values.  I added an if statement and division to set to 1.0 if >1, which fixes the issue in tests that I ran.  I'm not adding a unit test because the nelder-mead minimizer is fickle and it's sometimes hard to trigger, plus I have tested it in notebooks and it works as expected.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
