### PR TITLE
fix linting in bpz_lite, try bumping codecov workflow version

### DIFF
--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -35,3 +35,5 @@ jobs:
         python -m pytest tests --cov=bpz --cov-report=xml
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v4
+      env:
+       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -35,5 +35,5 @@ jobs:
         python -m pytest tests --cov=bpz --cov-report=xml
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -37,4 +37,5 @@ jobs:
       uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      with token: #{{secrets.CODECOV_TOKEN }}
+      with:
+        token: #{{secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -37,5 +37,3 @@ jobs:
       uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      with:
-        token: #{{secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -34,4 +34,7 @@ jobs:
       run: |
         python -m pytest tests --cov=bpz --cov-report=xml
     - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      with:
+        token: {{secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -34,4 +34,4 @@ jobs:
       run: |
         python -m pytest tests --cov=bpz --cov-report=xml
     - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -36,4 +36,5 @@ jobs:
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v4
       env:
-       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with token: #{{secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -34,6 +34,4 @@ jobs:
       run: |
         python -m pytest tests --cov=bpz --cov-report=xml
     - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v4
-      with:
-        token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
+      uses: codecov/codecov-action@v3

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -34,7 +34,6 @@ from rail.bpz.utils import RAIL_BPZ_DIR
 from rail.core.common_params import SHARED_PARAMS
 
 
-
 def nzfunc(z, z0, alpha, km, m, m0):  # pragma: no cover
     zm = z0 + (km * (m - m0))
     return np.power(z, alpha) * np.exp(-1. * np.power((z / zm), alpha))
@@ -71,7 +70,7 @@ class BPZliteInformer(CatInformer):
                           bands=SHARED_PARAMS,
                           err_bands=SHARED_PARAMS,
                           ref_band=SHARED_PARAMS,
-                          redshift_col=SHARED_PARAMS,   
+                          redshift_col=SHARED_PARAMS,
                           data_path=Param(str, "None",
                                           msg="data_path (str): file path to the "
                                           "SED, FILTER, and AB directories.  If left to "
@@ -259,7 +258,7 @@ class BPZliteEstimator(CatEstimator):
                           bands=SHARED_PARAMS,
                           ref_band=SHARED_PARAMS,
                           err_bands=SHARED_PARAMS,
-                          redshift_col=SHARED_PARAMS,   
+                          redshift_col=SHARED_PARAMS,
                           dz=Param(float, 0.01, msg="delta z in grid"),
                           unobserved_val=Param(float, -99.0, msg="value to be replaced with zero flux and given large errors for non-observed filters"),
                           data_path=Param(str, "None",
@@ -391,7 +390,7 @@ class BPZliteEstimator(CatEstimator):
         errs = self.config.err_bands
 
         fluxdict = {}
-        
+
         # Load the magnitudes
         zp_frac = e_mag2frac(np.array(self.config.zp_errors))
 
@@ -423,7 +422,6 @@ class BPZliteEstimator(CatEstimator):
             else:
                 data[bandname][obsmask] = -99.0
                 data[errname][obsmask] = 20.0
-
 
         # Only one set of mag errors
         mag_errs = np.array([data[er] for er in errs]).T
@@ -482,7 +480,7 @@ class BPZliteEstimator(CatEstimator):
         fluxdict['flux_err'] = flux_err
         m_0_col = self.config.bands.index(self.config.ref_band)
         fluxdict['mag0'] = mags[:, m_0_col]
-        
+
         return fluxdict
 
     def _estimate_pdf(self, flux_templates, kernel, flux, flux_err, mag_0, z):


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
a few minor linting changes in bpz_lite to get rid of some whitespace, test whether v4 of codecov action works where v3 is failing.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
