### PR TITLE
ran copier update, which changed testing action

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.3
+_commit: v0.3.3
 _src_path: gh:LSSTDESC/RAIL-project-template
 author_email: samuel.j.schmidt@gmail.com
 author_name: LSST Dark Energy Science Collaboration (DESC) Photo-z WG

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -34,4 +34,6 @@ jobs:
       run: |
         python -m pytest tests --cov=bpz --cov-report=xml
     - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Simply ran `copier update` which added the new line to the testing and coverage GitHub action, we'll see if the codecov report actually uploads properly now.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
