### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "desc-bpz",
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz-rail-base@git+https://github.com/LSSTDESC/rail_base@ceci2",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "desc-bpz",
-    "pz-rail-base@git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "desc-bpz",
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     "desc-bpz",
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "qp-prob[full]",
 ]
 

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -96,7 +96,7 @@ class BPZliteInformer(CatInformer):
     def __init__(self, args, **kwargs):
         """Init function, init config stuff
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.fo_arr = None
         self.kt_arr = None
         self.typmask = None
@@ -292,7 +292,7 @@ class BPZliteEstimator(CatEstimator):
     def __init__(self, args, **kwargs):
         """Constructor, build the CatEstimator, then do BPZ specific setup
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
         datapath = self.config["data_path"]
         if datapath is None or datapath == "None":

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -93,10 +93,10 @@ class BPZliteInformer(CatInformer):
                           init_km=Param(float, 0.1, msg="initial guess for km in training"),
                           type_file=Param(str, "", msg="name of file with the broad type fits for the training data"))
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Init function, init config stuff
         """
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.fo_arr = None
         self.kt_arr = None
         self.typmask = None
@@ -289,10 +289,10 @@ class BPZliteEstimator(CatEstimator):
                                             msg="a minimum floor for the magnitude errors to prevent a "
                                             "large chi^2 for very very bright objects"))
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor, build the CatEstimator, then do BPZ specific setup
         """
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
         datapath = self.config["data_path"]
         if datapath is None or datapath == "None":


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.