### PR TITLE
add quotes to protect a docstring for sphinx

### DIFF
--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -57,8 +57,12 @@ class BPZliteInformer(CatInformer):
     p(T|m) = exp(-kt(m-m0))
     where m0 is a constant and we fit for values of kt
     For p(z|T,m) we have
+
+    ```
     P(z|T,m) = f_x*z0_x^a *exp(-(z/zm_x)^a)
     where zm_x = z0_x*(km_x-m0)
+    ```
+
     where f_x is the type fraction from p(T|m), and we fit for values of
     z0, km, and a for each type.  These parameters are then fed to the BPZ
     prior for use in the estimation stage.


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
