### PR TITLE
fix typo in nt_array default #63

### DIFF
--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -82,7 +82,7 @@ class BPZliteInformer(CatInformer):
                           spectra_file=Param(str, "CWWSB4.list",
                                              msg="name of the file specifying the list of SEDs to use"),
                           m0=Param(float, 20.0, msg="reference apparent mag, used in prior param"),
-                          nt_array=Param(list, [1, 2, 3], msg="list of integer number of templates per 'broad type', "
+                          nt_array=Param(list, [1, 2, 5], msg="list of integer number of templates per 'broad type', "
                                          "must be in same order as the template set, and must sum to the same number "
                                          "as the # of templates in the spectra file"),
                           mmin=Param(float, 18.0, msg="lowest apparent mag in ref band, lower values ignored"),


### PR DESCRIPTION
addresses #63 simple typo in the nt_array default value.  golden spike nb should run properly once this is fixed.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
