### PR TITLE
add zero point offsets and broad type calculation

### DIFF
--- a/src/rail/bpz/__init__.py
+++ b/src/rail/bpz/__init__.py
@@ -1,3 +1,4 @@
 from rail.estimation.algos.bpz_lite import *
+from rail.estimation.algos.bpz_preprocess import *
 
 from ._version import __version__

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -120,6 +120,17 @@ class BPZliteInformer(CatInformer):
             True,
             msg="if True, just return the default HDFN prior params rather than fitting",
         ),
+        override_file_offsets=Param(
+            bool,
+            False,
+            msg="if False, will use zeropoint offsets from pkl file, "
+            "if True, will instead use values in zp_offsets param"
+        ),
+        zp_offsets=Param(
+            list,
+            default_offset_array,
+            msg="zero point offsets calculated from preInformer stage"
+        ),
     )
 
     def __init__(self, args, **kwargs):
@@ -234,6 +245,17 @@ class BPZliteInformer(CatInformer):
 
     def run(self):
         """compute the best fit prior parameters"""
+        if self.config.hdf5_groupname:
+            training_data = self.get_data("input")[self.config.hdf5_groupname]
+        else:  # pragma: no cover
+            training_data = self.get_data("input")
+
+        # convert training data format to numpy dictionary
+        if tables_io.types.table_type(training_data) != 1:
+            training_data = self._convert_table_format(
+                training_data, out_fmt_str="numpyDict"
+            )
+        ngal = len(training_data[self.config.ref_band])
         if self.config.output_hdfn:
             # the parameters for the HDFN prior
             self.fo_arr = np.array([0.35, 0.5])
@@ -243,21 +265,11 @@ class BPZliteInformer(CatInformer):
             self.a_arr = np.array([2.465, 1.806, 0.906])
             self.m0 = 20.0
             self.nt_array = self.config.nt_array
-            zeropoints = np.zeros(len(self.config.bands))
+            if not self.config.override_file_offsets:
+                _, _, zeropoints = self._get_broad_type(ngal)
+            else: zeropoints = np.zeros(len(self.config.bands))
         else:
             self.m0 = self.config.m0
-            if self.config.hdf5_groupname:
-                training_data = self.get_data("input")[self.config.hdf5_groupname]
-            else:  # pragma: no cover
-                training_data = self.get_data("input")
-
-            # convert training data format to numpy dictionary
-            if tables_io.types.table_type(training_data) != 1:
-                training_data = self._convert_table_format(
-                    training_data, out_fmt_str="numpyDict"
-                )
-
-            ngal = len(training_data[self.config.ref_band])
 
             if self.config.ref_band not in training_data.keys():  # pragma: no cover
                 raise KeyError(

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -265,9 +265,10 @@ class BPZliteInformer(CatInformer):
             self.a_arr = np.array([2.465, 1.806, 0.906])
             self.m0 = 20.0
             self.nt_array = self.config.nt_array
-            if not self.config.override_file_offsets:
+            if self.config.override_file_offsets:  # pragma: no cover
+                zeropoints =  np.zeros(len(self.config.bands))
+            else: 
                 _, _, zeropoints = self._get_broad_type(ngal)
-            else: zeropoints = np.zeros(len(self.config.bands))
         else:
             self.m0 = self.config.m0
 

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -33,6 +33,9 @@ from rail.estimation.estimator import CatEstimator, CatInformer
 from rail.utils.path_utils import RAILDIR
 
 
+default_offset_array = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+
 def nzfunc(z, z0, alpha, km, m, m0):  # pragma: no cover
     zm = z0 + (km * (m - m0))
     return np.power(z, alpha) * np.exp(-1.0 * np.power((z / zm), alpha))
@@ -135,7 +138,7 @@ class BPZliteInformer(CatInformer):
         ngal = len(self.mags)
         probs = np.zeros([self.ntyp, ngal])
         foarr = frac_params[: self.ntyp - 1]
-        ktarr = frac_params[self.ntyp - 1 :]
+        ktarr = np.fabs(frac_params[self.ntyp - 1 :])
         for i in range(self.ntyp - 1):
             probs[i, :] = [
                 foarr[i] * np.exp(-1.0 * ktarr[i] * (mag - self.m0))
@@ -175,7 +178,7 @@ class BPZliteInformer(CatInformer):
                 print("bad norm for f0, normalizing")
                 tmpfo /= fracnorm
             self.fo_arr = tmpfo
-            self.kt_arr = frac_results[self.ntyp - 1 :]
+            self.kt_arr = np.fabs(frac_results[self.ntyp - 1 :])
 
     def _dndz_likelihood(self, params):
         mags = self.mags[self.typmask]
@@ -221,10 +224,13 @@ class BPZliteInformer(CatInformer):
         typefile = self.config.type_file
         if typefile == "":  # pragma: no cover
             typedata = np.zeros(ngal, dtype=int)
-        else:
-            typedata = tables_io.read(typefile)["types"]  # pragma: no cover
+            zeropoints = np.zeros(len(self.config.bands))
+        else:  # pragma: no cover
+            tdata = tables_io.read(typefile)
+            typedata = tdata["types"]["broad_type"]  # pragma: no cover
+            zeropoints = tdata["offsets"]["zp_offsets"]
         numtypes = len(list(set(typedata)))
-        return numtypes, typedata
+        return numtypes, typedata, zeropoints
 
     def run(self):
         """compute the best fit prior parameters"""
@@ -237,6 +243,7 @@ class BPZliteInformer(CatInformer):
             self.a_arr = np.array([2.465, 1.806, 0.906])
             self.m0 = 20.0
             self.nt_array = self.config.nt_array
+            zeropoints = np.zeros(len(self.config.bands))
         else:
             self.m0 = self.config.m0
             if self.config.hdf5_groupname:
@@ -262,7 +269,7 @@ class BPZliteInformer(CatInformer):
                 )
 
             # cal function to get broad types
-            Ntyp, broad_types = self._get_broad_type(ngal)
+            Ntyp, broad_types, zeropoints = self._get_broad_type(ngal)
             self.ntyp = Ntyp
             # trim data to between mmin and mmax
             ref_mags = training_data[self.config.ref_band]
@@ -286,13 +293,18 @@ class BPZliteInformer(CatInformer):
             self.a_arr = np.abs(self.a_arr)
 
         self.model = dict(
-            fo_arr=self.fo_arr,
-            kt_arr=self.kt_arr,
-            zo_arr=self.zo_arr,
-            km_arr=self.km_arr,
-            a_arr=self.a_arr,
-            mo=self.m0,
-            nt_array=self.config.nt_array,
+            priormodel=dict(
+                fo_arr=self.fo_arr,
+                kt_arr=self.kt_arr,
+                zo_arr=self.zo_arr,
+                km_arr=self.km_arr,
+                a_arr=self.a_arr,
+                mo=self.m0,
+                nt_array=self.config.nt_array,
+            ),
+            zp_offsets=dict(
+                offsets=zeropoints
+            ),
         )
         self.add_data("model", self.model)
 
@@ -371,6 +383,17 @@ class BPZliteEstimator(CatEstimator):
             msg="a minimum floor for the magnitude errors to prevent a "
             "large chi^2 for very very bright objects",
         ),
+        override_file_offsets=Param(
+            bool,
+            False,
+            msg="if False, will use zeropoint offsets from pkl file, "
+            "if True, will instead use values in zp_offsets param"
+        ),
+        zp_offsets=Param(
+            list,
+            default_offset_array,
+            msg="zero point offsets calculated from preInformer stage"
+        ),
     )
 
     def __init__(self, args, **kwargs):
@@ -411,6 +434,7 @@ class BPZliteEstimator(CatEstimator):
                 f"err_bands, {len(self.config.err_bands)} and "
                 f"filter_list {len(self.config.filter_list)} are not the same!"
             )
+        self.config.zp_offsets = np.array(self.config.zp_offsets)
 
     def _initialize_run(self):
         super()._initialize_run()
@@ -437,8 +461,10 @@ class BPZliteEstimator(CatEstimator):
                 self.comm.Barrier()
 
     def open_model(self, **kwargs):
-        CatEstimator.open_model(self, **kwargs)
-        self.modeldict = self.model
+        self.model = CatEstimator.open_model(self, **kwargs)
+        catmodeldict = self.model
+        self.modeldict = catmodeldict["priormodel"]
+        self.zp_off_from_file = catmodeldict["zp_offsets"]["offsets"]
 
     def _load_templates(self):
         from desc_bpz.useful_py3 import get_data, get_str, match_resol
@@ -496,11 +522,19 @@ class BPZliteEstimator(CatEstimator):
 
         # replace non-detects with 99 and mag_err with lim_mag for consistency
         # with typical BPZ performance
-        for bandname, errname in zip(bands, errs):
+        for ii, (bandname, errname) in enumerate(zip(bands, errs)):
+            # Need to apply zero point offsets after detection mask!
+            # Was here, move to after mask determination
             if np.isnan(self.config.nondetect_val):  # pragma: no cover
                 detmask = np.isnan(data[bandname])
             else:
                 detmask = np.isclose(data[bandname], self.config.nondetect_val)
+            # Subtract off the zero point offsets
+            if self.config.override_file_offsets:
+                zpoff = self.config.zp_offsets
+            else:
+                zpoff = self.zp_off_from_file
+            data[bandname] -= zpoff[ii]
             data[bandname][detmask] = 99.0
             data[errname][detmask] = self.config.mag_limits[bandname]
 
@@ -565,7 +599,7 @@ class BPZliteEstimator(CatEstimator):
         nonobserved = -99.0
         unobserved = np.isclose(mags, nonobserved)
         flux[unobserved] = 0.0
-        flux_err[unobserved] = 1e108
+        flux_err[unobserved] = 1e28
 
         # Upate the flux dictionary with new things we have calculated
         fluxdict["flux"] = flux
@@ -644,7 +678,7 @@ class BPZliteEstimator(CatEstimator):
 
         # put in that format here
         test_data = self._preprocess_magnitudes(data)
-        m_0_col = self.config.bands.index(self.config.ref_band)
+        # m_0_col = self.config.bands.index(self.config.ref_band)
 
         nz = len(self.zgrid)
         ng = test_data["flux"].shape[0]

--- a/src/rail/estimation/algos/bpz_preprocess.py
+++ b/src/rail/estimation/algos/bpz_preprocess.py
@@ -39,7 +39,7 @@ class BPZlitePreEstimator(CatEstimator):
     """
 
     name = "BPZlitePreEstimator"
-    entrypoint_function = "preestimate"  # the user-facing science function for this class
+    entrypoint_function = "estimate"  # the user-facing science function for this class
     interactive_function = "bpz_lite_preestimator"
     config_options = CatEstimator.config_options.copy()
     config_options.update(

--- a/src/rail/estimation/algos/bpz_preprocess.py
+++ b/src/rail/estimation/algos/bpz_preprocess.py
@@ -1,0 +1,477 @@
+"""
+Port of *some* parts of BPZ, not the entire codebase.
+Much of the code is directly ported from BPZ, written
+by Txitxo Benitez and Dan Coe (Benitez 2000), which
+was modified by Will Hartley and Sam Schmidt to make
+it python3 compatible.  It was then modified to work
+with TXPipe and ceci by Joe Zuntz and Sam Schmidt
+for BPZPipe.  This version for RAIL removes a few
+features and concentrates on just predicting the PDF.
+
+Missing from full BPZ:
+-no chi^2, ML quantities
+-plotting utilities
+-no output of 2D probs (maybe later add back in)
+-no 'cluster' prior mods
+
+"""
+
+import glob
+import os
+
+import numpy as np
+import tables_io
+from ceci.config import StageParameter as Param
+from rail.core.common_params import SHARED_PARAMS
+from rail.core.data import Hdf5Handle
+from rail.estimation.estimator import CatEstimator
+from rail.utils.path_utils import RAILDIR
+
+
+default_offset_array = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+
+class BPZlitePreEstimator(CatEstimator):
+    """This is a 'pre-estimate' stage that does two things:
+    1: compute the zero-point offsets for a training/test set
+    2: computes the best "broad type" for a training set that can be used to train
+    new prior params in the BPZliteInformer stage
+    """
+
+    name = "BPZlitePreEstimator"
+    entrypoint_function = "preestimate"  # the user-facing science function for this class
+    interactive_function = "bpz_lite_preestimator"
+    config_options = CatEstimator.config_options.copy()
+    config_options.update(
+        zmin=SHARED_PARAMS,
+        zmax=SHARED_PARAMS,
+        nzbins=SHARED_PARAMS,
+        nondetect_val=SHARED_PARAMS,
+        mag_limits=SHARED_PARAMS,
+        bands=SHARED_PARAMS,
+        err_bands=SHARED_PARAMS,
+        ref_band=SHARED_PARAMS,
+        redshift_col=SHARED_PARAMS,
+        bpz_ref_data_path=Param(
+            str,
+            "None",
+            msg="bpz_ref_data_path (str): file path to the "
+            "SED, FILTER, and AB directories.  If left to "
+            "default `None` it will use the install "
+            "directory for rail + rail/examples_data/estimation_data/data",
+        ),
+        spectra_file=Param(
+            str,
+            "CWWSB4.list",
+            msg="name of the file specifying the list of SEDs to use",
+        ),
+        m0=Param(float, 20.0, msg="reference apparent mag, used in prior param"),
+        nt_array=Param(
+            list,
+            [1, 2, 5],
+            msg="list of integer number of templates per 'broad type', "
+            "must be in same order as the template set, and must sum to the same number "
+            "as the # of templates in the spectra file",
+        ),
+        mmin=Param(
+            float, 18.0, msg="lowest apparent mag in ref band, lower values ignored"
+        ),
+        mmax=Param(
+            float, 29.0, msg="highest apparent mag in ref band, higher values ignored"
+        ),
+        dz=Param(float, 0.01, msg="delta z in grid"),
+        unobserved_val=Param(
+            float,
+            -99.0,
+            msg="value to be replaced with zero flux and given large errors for non-observed filters",
+        ),
+        filter_list=SHARED_PARAMS,
+        madau_flag=Param(
+            str,
+            "no",
+            msg="set to 'yes' or 'no' to set whether to include intergalactic "
+            "Madau reddening when constructing model fluxes",
+        ),
+        no_prior=Param(bool, False, msg="set to True if you want to run with no prior"),
+        p_min=Param(
+            float,
+            0.005,
+            msg="BPZ sets all values of "
+            "the PDF that are below p_min*peak_value to 0.0, "
+            "p_min controls that fractional cutoff",
+        ),
+        gauss_kernel=Param(
+            float,
+            0.0,
+            msg="gauss_kernel (float): BPZ "
+            "convolves the PDF with a kernel if this is set "
+            "to a non-zero number",
+        ),
+        zp_errors=SHARED_PARAMS,
+        mag_err_min=Param(
+            float,
+            0.005,
+            msg="a minimum floor for the magnitude errors to prevent a "
+            "large chi^2 for very very bright objects",
+        ),
+        only_type=Param(
+            bool,
+            True,
+            msg="if set to True, fixes the redshift to be true z from "
+            "redshift_col for computing best broad type and offsets"
+        ),
+        zp_offsets=Param(
+            list,
+            default_offset_array,
+            msg="zero point offsets to apply (if doing iteratively for type fit)"
+        ),
+    )
+    outputs = [("output", Hdf5Handle)]
+
+    def __init__(self, args, **kwargs):
+        """Init function, init config stuff"""
+        super().__init__(args, **kwargs)
+        self.fo_arr = None
+        self.kt_arr = None
+        self.typmask = None
+        self.ntyp = None
+        self.mags = None
+        self.szs = None
+        self.besttypes = None
+        self.best_broadtypes = None
+        self.m0 = self.config.m0
+        self.config.zp_offsets = np.array(self.config.zp_offsets)
+
+        datapath = self.config["bpz_ref_data_path"]
+        if datapath is None or datapath == "None":
+            tmpdatapath = os.path.join(
+                RAILDIR, "rail/examples_data/estimation_data/data"
+            )
+            os.environ["BPZDATAPATH"] = tmpdatapath
+            self.bpz_ref_data_path = tmpdatapath
+        else:  # pragma: no cover
+            self.bpz_ref_data_path = datapath
+            os.environ["BPZDATAPATH"] = self.bpz_ref_data_path
+        if not os.path.exists(self.bpz_ref_data_path):  # pragma: no cover
+            raise FileNotFoundError(
+                "BPZDATAPATH "
+                + self.bpz_ref_data_path
+                + " does not exist! Check value of bpz_ref_data_path in config file!"
+            )
+
+        self.flux_templates = self._load_templates()
+
+    def _load_templates(self):
+        from desc_bpz.useful_py3 import get_data, get_str, match_resol
+
+        # The redshift range we will evaluate on
+        self.zgrid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins)
+        z = self.zgrid
+
+        bpz_ref_data_path = self.bpz_ref_data_path
+        filters = self.config.filter_list
+
+        spectra_file = os.path.join(bpz_ref_data_path, "SED", self.config.spectra_file)
+        spectra = [s[:-4] for s in get_str(spectra_file)]
+
+        nt = len(spectra)
+        nf = len(filters)
+        nz = len(z)
+        flux_templates = np.zeros((nz, nt, nf))
+
+        ab_dir = os.path.join(bpz_ref_data_path, "AB")
+        os.makedirs(ab_dir, exist_ok=True)
+
+        # make a list of all available AB files in the AB directory
+        ab_file_list = glob.glob(ab_dir + "/*.AB")
+        ab_file_db = [os.path.split(x)[-1] for x in ab_file_list]
+
+        for i, s in enumerate(spectra):
+            for j, f in enumerate(filters):
+                model = f"{s}.{f}.AB"
+                if model not in ab_file_db:  # pragma: no cover
+                    self._make_new_ab_file(s, f)
+                model_path = os.path.join(bpz_ref_data_path, "AB", model)
+                zo, f_mod_0 = get_data(model_path, (0, 1))
+                flux_templates[:, i, j] = match_resol(zo, f_mod_0, z)
+
+        return flux_templates
+
+    def _make_new_ab_file(self, spectrum, filter_):  # pragma: no cover
+        from desc_bpz.bpz_tools_py3 import ABflux
+
+        new_file = f"{spectrum}.{filter_}.AB"
+        print(f"  Generating new AB file {new_file}....")
+        ABflux(spectrum, filter_, self.config.madau_flag)
+
+    def _preprocess_magnitudes(self, data):
+        from desc_bpz.bpz_tools_py3 import e_mag2frac
+
+        bands = self.config.bands
+        errs = self.config.err_bands
+
+        fluxdict = {}
+
+        # Load the magnitudes
+        zp_frac = e_mag2frac(np.array(self.config.zp_errors))
+
+        # replace non-detects with 99 and mag_err with lim_mag for consistency
+        # with typical BPZ performance
+        for ii, (bandname, errname) in enumerate(zip(bands, errs)):
+            if np.isnan(self.config.nondetect_val):  # pragma: no cover
+                detmask = np.isnan(data[bandname])
+            else:
+                detmask = np.isclose(data[bandname], self.config.nondetect_val)
+            data[bandname] -= self.config.zp_offsets[ii]
+            data[bandname][detmask] = 99.0
+            data[errname][detmask] = self.config.mag_limits[bandname]
+
+        # replace non-observations with -99, again to match BPZ standard
+        # below the fluxes for these will be set to zero but with enormous
+        # flux errors
+        for bandname, errname in zip(bands, errs):
+            if np.isnan(self.config.unobserved_val):  # pragma: no cover
+                obsmask = np.isnan(data[bandname])
+            else:
+                obsmask = np.isclose(data[bandname], self.config.unobserved_val)
+            data[bandname][obsmask] = -99.0
+            data[errname][obsmask] = 20.0
+
+        # Only one set of mag errors
+        mag_errs = np.array([data[er] for er in errs]).T
+
+        # Group the magnitudes and errors into one big array
+        mags = np.array([data[b] for b in bands]).T
+
+        # Clip to min mag errors.
+        # JZ: Changed the max value here to 20 as values in the lensfit
+        # catalog of ~ 200 were causing underflows below that turned into
+        # zero errors on the fluxes and then nans in the output
+        np.clip(mag_errs, self.config.mag_err_min, 20, mag_errs)
+
+        # Convert to pseudo-fluxes
+        flux = 10.0 ** (-0.4 * mags)
+        flux_err = flux * (10.0 ** (0.4 * mag_errs) - 1.0)
+
+        # Check if an object is seen in each band at all.
+        # Fluxes not seen at all are listed as infinity in the input,
+        # so will come out as zero flux and zero flux_err.
+        # Check which is which here, to use with the ZP errors below
+        seen1 = (flux > 0) & (flux_err > 0)
+        seen = np.where(seen1)
+        # unseen = np.where(~seen1)
+        # replace Joe's definition with more standard BPZ style
+        nondetect = 99.0
+        nondetflux = 10.0 ** (-0.4 * nondetect)
+        unseen = np.isclose(flux, nondetflux, atol=nondetflux * 0.5)
+
+        # replace mag = 99 values with 0 flux and 1 sigma limiting magnitude
+        # value, which is stored in the mag_errs column for non-detects
+        # NOTE: We should check that this same convention will be used in
+        # LSST, or change how we handle non-detects here!
+        flux[unseen] = 0.0
+        flux_err[unseen] = 10.0 ** (-0.4 * np.abs(mag_errs[unseen]))
+
+        # Add zero point magnitude errors.
+        # In the case that the object is detected, this
+        # correction depends onthe flux.  If it is not detected
+        # then BPZ uses half the errors instead
+        add_err = np.zeros_like(flux_err)
+        add_err[seen] = ((zp_frac * flux) ** 2)[seen]
+        add_err[unseen] = ((zp_frac * 0.5 * flux_err) ** 2)[unseen]
+        flux_err = np.sqrt(flux_err**2 + add_err)
+
+        # Convert non-observed objects to have zero flux
+        # and enormous error, so that their likelihood will be
+        # flat. This follows what's done in the bpz script.
+        nonobserved = -99.0
+        unobserved = np.isclose(mags, nonobserved)
+        flux[unobserved] = 0.0
+        flux_err[unobserved] = 1e30
+
+        # Upate the flux dictionary with new things we have calculated
+        fluxdict["flux"] = flux
+        fluxdict["flux_err"] = flux_err
+        m_0_col = self.config.bands.index(self.config.ref_band)
+        fluxdict["mag0"] = mags[:, m_0_col]
+
+        return fluxdict
+
+    def _types_ratios(self, flux_templates, flux, flux_err, mag_0, z, sz=None):
+        from desc_bpz.bpz_tools_py3 import p_c_z_t
+        from desc_bpz.prior_from_dict import prior_function
+
+        modeldict = self.modeldict
+        p_min = self.config.p_min
+        nt = flux_templates.shape[1]
+
+        # The likelihood and prior...
+        pczt = p_c_z_t(flux, flux_err, flux_templates)
+        L = pczt.likelihood
+
+        if self.config.only_type:
+            # fix to only include the true z row
+            whichrow = np.searchsorted(z, sz)
+            # set all rows of prior to zero except the specz row
+            # and set "flat" prior for that row
+            P = np.zeros(L.shape)
+            P[whichrow, :] = 1. / nt
+        else:
+
+            # old prior code returns NoneType for prior if "flat" or "none"
+            # just hard code the no prior case for now for backward compatibility
+            if self.config.no_prior:  # pragma: no cover
+                P = np.ones(L.shape)
+            else:
+                # set num templates to nt, which is hardcoding to "interp=0"
+                # in BPZ, i.e. do not create any interpolated templates
+                P = prior_function(z, mag_0, modeldict, nt)
+
+        post = L * P
+        # Right now we jave the joint PDF of p(z,template). Marginalize
+        # over the templates to just get p(z)
+        post_z = post.sum(axis=1)
+
+        # Find the mode
+        zpos = np.argmax(post_z)
+        zmode = self.zgrid[zpos]
+
+        # Trim probabilities
+        # below a certain threshold pct of p_max
+        p_max = post_z.max()
+        post_z[post_z < (p_max * p_min)] = 0
+
+        # Normalize in the same way that BPZ does
+        # But, only normalize if the elements don't sum to zero
+        # if they are all zero, just leave p(z) as all zeros, as no templates
+        # are a good fit.
+        if not np.isclose(post_z.sum(), 0.0):
+            post_z /= post_z.sum()
+
+        # Find T_B, the highest probability template *at zmode*
+        tmode = post[zpos, :]
+        t_b = np.argmax(tmode)
+
+        ft = flux_templates[zpos, t_b, :]
+
+        # frat = flux/ft
+        # fw = flux/flux_err
+
+        return zmode, t_b, ft
+
+    def run(self):
+        self.refcol = self.config.bands.index(self.config.ref_band)
+        self.nt_array = self.config.nt_array
+        if not self.config.no_prior:
+            # the parameters for the HDFN prior
+            self.fo_arr = np.array([0.35, 0.5])
+            self.kt_arr = np.array([0.45, 0.147])
+            self.zo_arr = np.array([0.431, 0.39, 0.0626])
+            self.km_arr = np.array([0.0913, 0.0636, 0.123])
+            self.a_arr = np.array([2.465, 1.806, 0.906])
+            self.m0 = 20.0
+            self.nt_array = self.config.nt_array
+            self.modeldict = dict(
+                fo_arr=self.fo_arr,
+                kt_arr=self.kt_arr,
+                zo_arr=self.zo_arr,
+                km_arr=self.km_arr,
+                a_arr=self.a_arr,
+                mo=self.m0,
+                nt_array=self.nt_array
+            )
+        else:
+            self.m0 = self.config.m0
+            self.modeldict = dict(fakeparam=0.0)  # not actually used in this case
+
+        if self.config.hdf5_groupname:
+            training_data = self.get_data("input")[self.config.hdf5_groupname]
+        else:  # pragma: no cover
+            training_data = self.get_data("input")
+
+        # convert training data format to numpy dictionary
+        if tables_io.types.table_type(training_data) != 1:  # pragma: no cover
+            training_data = self._convert_table_format(
+                training_data, out_fmt_str="numpyDict"
+            )
+
+        # ngal = len(training_data[self.config.ref_band])
+
+        if self.config.ref_band not in training_data.keys():  # pragma: no cover
+            raise KeyError(
+                f"ref_band {self.config.ref_band} not found in input data!"
+            )
+        if self.config.redshift_col not in training_data.keys():  # pragma: no cover
+            raise KeyError(
+                f"redshift column {self.config.redshift_col} not found in input data!"
+            )
+
+        #
+        test_data = self._preprocess_magnitudes(training_data)
+        # m_0_col = self.config.bands.index(self.config.ref_band)
+
+        # nz = len(self.zgrid)
+        ng = test_data["flux"].shape[0]
+        nf = len(self.config.filter_list)
+
+        zmode = np.zeros(ng)
+        ft = np.zeros([ng, nf])
+        tb = np.zeros(ng)
+        # broad_type = np.zeros(ng)
+        flux_temps = self.flux_templates
+        zgrid = self.zgrid
+        # Loop over all ng galaxies!
+        for i in range(ng):
+            mag_0 = test_data["mag0"][i]
+            flux = test_data["flux"][i]
+            flux_err = test_data["flux_err"][i]
+            if self.config.only_type:
+                truez = training_data[self.config.redshift_col][i]
+            else:
+                truez = None
+            zmode[i], tb[i], ft[i, :] = self._types_ratios(
+                flux_temps, flux, flux_err, mag_0, zgrid, truez
+            )
+            # normalize the ftSrefcol
+            # after removing zero values
+            ftthresh = 1.e-50
+            ftmask = ft[self.refcol] < ftthresh
+            ft[self.refcol][ftmask] = ftthresh
+            ft = ft * flux[self.refcol] / ft[self.refcol]
+
+        frat = test_data['flux'] / ft
+        # fw = test_data['flux'] / test_data['flux_err']
+
+        offsets = np.zeros(nf)
+        totoffsets = np.zeros(nf)
+
+        for i in range(nf):
+            fmask = np.logical_and(np.isfinite(frat[:, i]), frat[:, i] > 1.e-38)
+            xfr = frat[:, i][fmask]
+            offsets[i] = -2.5 * np.log10(np.mean(xfr))
+
+        # set so that zero offset for ref col
+        norm_offset = offsets[self.refcol]
+        offsets -= norm_offset
+
+        # Need to add offsets from config to get total offsets in case
+        # this was done iteratively
+        for i in range(nf):
+            totoffsets[i] = offsets[i] + self.config.zp_offsets[i]
+
+        # find broad types
+        xedges = np.concatenate([np.array([0]), self.nt_array])
+        edges = np.zeros(len(xedges), dtype=float)
+        for ii in range(len(xedges)):
+            edges[ii] = np.sum(xedges[:ii + 1])
+        edges -= 0.005
+        # find broad types, subtract 1 so they are zero-indexed
+        btype = np.searchsorted(edges, tb, side='left') - 1
+
+        outdict = dict(
+            offsets=dict(
+                zp_offsets=np.array(totoffsets)),
+            types=dict(broad_type=np.array(btype),
+                       tb=np.array(tb))
+        )
+        self.add_data("output", outdict)

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -5,13 +5,14 @@ import numpy as np
 import pytest
 import scipy.special
 import tables_io
-from rail.core.data import DataStore, TableHandle
-from rail.core.stage import RailStage
+from rail.core.data import TableHandle
 from rail.utils.path_utils import RAILDIR
 from rail.utils.testing_utils import one_algo
 
 from rail.bpz.utils import RAIL_BPZ_DIR
 from rail.estimation.algos import bpz_lite
+from rail.estimation.algos.bpz_preprocess import BPZlitePreEstimator
+
 
 sci_ver_str = scipy.__version__.split(".")
 
@@ -44,12 +45,15 @@ def test_bpz_train(ntarray, inputdata, groupname, size):
         "model": "testmodel_bpz.pkl",
         "output_hdfn": False,
     }
+    fakeoffsets = np.zeros(6)
+    offsets = dict(zp_offsets=fakeoffsets)
     if len(ntarray) == 2:
         broad_types = np.random.randint(2, size=size)
     else:
         broad_types = np.zeros(size, dtype=int)
-    typedict = dict(types=broad_types)
-    tables_io.write(typedict, "tmp_broad_types.hdf5")
+    broaddict = dict(broad_type=broad_types)
+    outerdict = dict(offsets=offsets, types=broaddict)
+    tables_io.write(outerdict, "tmp_broad_types.hdf5")
     train_algo = bpz_lite.BPZliteInformer
     # DS.clear()
     # training_data = DS.read_file("training_data", TableHandle, inputdata)
@@ -60,8 +64,9 @@ def test_bpz_train(ntarray, inputdata, groupname, size):
     expected_keys = ["fo_arr", "kt_arr", "zo_arr", "km_arr", "a_arr", "mo", "nt_array"]
     with open("testmodel_bpz.pkl", "rb") as f:
         tmpmodel = pickle.load(f)
+        priormodel = tmpmodel['priormodel']
     for key in expected_keys:
-        assert key in tmpmodel.keys()
+        assert key in priormodel.keys()
     os.remove("tmp_broad_types.hdf5")
 
 
@@ -86,8 +91,9 @@ def test_output_hdfn_inform():
     expected_keys = ["fo_arr", "kt_arr", "zo_arr", "km_arr", "a_arr", "mo", "nt_array"]
     with open("testmodel_bpz.pkl", "rb") as f:
         tmpmodel = pickle.load(f)
+        priormodel = tmpmodel['priormodel']
     for key in expected_keys:
-        assert key in tmpmodel.keys()
+        assert key in priormodel.keys()
 
 
 def test_bpz_lite():
@@ -114,7 +120,7 @@ def test_bpz_lite():
         "nt_array": [8],
         "model": "testmodel_bpz.pkl",
     }
-    zb_expected = np.array([0.16, 0.12, 0.0, 0.12, 0.05, 0.14, 0.11, 0.14, 0.05, 0.16])
+    # zb_expected = np.array([0.16, 0.12, 0.0, 0.12, 0.05, 0.14, 0.11, 0.14, 0.05, 0.16])
     train_algo = None
     pz_algo = bpz_lite.BPZliteEstimator
     results, rerun_results, rerun3_results = one_algo(
@@ -168,6 +174,44 @@ def test_bpz_wHDFN_prior(inputdata, groupname):
     os.remove(pz.get_output(pz.get_aliased_tag("output"), final_name=True))
 
 
+def test_bpz_zeropt_override():
+    estim_config_dict = {
+        "zmin": 0.0,
+        "zmax": 3.0,
+        "dz": 0.01,
+        "nzbins": 301,
+        "bpz_ref_data_path": None,
+        "columns_file": os.path.join(
+            RAIL_BPZ_DIR, "rail/examples_data/estimation_data/configs/test_bpz.columns"
+        ),
+        "spectra_file": "CWWSB4.list",
+        "madau_flag": "no",
+        "ref_band": "mag_i_lsst",
+        "prior_file": "flat",
+        "p_min": 0.005,
+        "gauss_kernel": 0.1,
+        "zp_errors": np.array([0.01, 0.01, 0.01, 0.01, 0.01, 0.01]),
+        "mag_err_min": 0.005,
+        "hdf5_groupname": "photometry",
+        "nt_array": [1, 2, 5],
+        "model": os.path.join(
+            RAILDIR, "rail/examples_data/estimation_data/data/CWW_HDFN_prior.pkl"
+        ),
+        "override_file_offsets": True,
+        "zp_offsets": np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+    }
+    zb_expected = np.array([0.18, 2.88, 0.14, 0.19, 2.91, 0.18, 0.21, 0.21, 2.98, 2.92])
+
+    # validation_data = DS.read_file("validation_data", TableHandle, inputdata)
+    validation_data = TableHandle("validation_data", path=validdata)
+    validation_data = validation_data.read()
+    pz = bpz_lite.BPZliteEstimator.make_stage(name="bpz_hdfn", **estim_config_dict)
+    results = pz.estimate(validation_data)
+    assert np.isclose(results.data.ancil["zmode"], zb_expected, atol=0.05).all()
+    # DS.clear()
+    os.remove(pz.get_output(pz.get_aliased_tag("output"), final_name=True))
+
+
 def test_wrong_number_of_filters():
     train_config_dict = {}
     estim_config_dict = {
@@ -196,3 +240,52 @@ def test_wrong_number_of_filters():
         _, _, _ = one_algo(
             "BPZ_lite", train_algo, pz_algo, train_config_dict, estim_config_dict
         )
+
+
+def test_bpz_preestimation():
+    zp_off = np.zeros(6)
+    pre_est_dict = dict(zp_offsets=zp_off, only_type=False, output="test_preestimation.hdf5")
+    train_data = tables_io.read(traindata)
+
+    prestage = BPZlitePreEstimator.make_stage(name="test", **pre_est_dict)
+    pre_results = prestage.estimate(train_data)
+
+    newoff = pre_results()['offsets']['zp_offsets']
+    newtypes = pre_results()['types']['broad_type']
+    assert len(newtypes) == 100
+    assert len(newoff) == 6
+    os.remove("test_preestimation.hdf5")
+
+
+def test_bpz_preestimation_onlytype():
+    zp_off = np.zeros(6)
+    pre_est_dict = dict(zp_offsets=zp_off, only_type=True, output="test_preestimation_otype.hdf5")
+    train_data = tables_io.read(traindata)
+
+    prestage = BPZlitePreEstimator.make_stage(name="test", **pre_est_dict)
+    pre_results = prestage.estimate(train_data)
+
+    newoff = pre_results()['offsets']['zp_offsets']
+    newtypes = pre_results()['types']['broad_type']
+    assert len(newoff) == 6
+    assert len(newtypes) == 100
+
+    os.remove("test_preestimation_otype.hdf5")
+
+
+def test_bpz_preestimation_noprior():
+    zp_off = np.zeros(6)
+    pre_est_dict = dict(zp_offsets=zp_off,
+                        only_type=True,
+                        no_prior=True,
+                        output="test_preestimation_noprior.hdf5")
+    train_data = tables_io.read(traindata)
+
+    prestage = BPZlitePreEstimator.make_stage(name="test", **pre_est_dict)
+    pre_results = prestage.estimate(train_data)
+
+    newoff = pre_results()['offsets']['zp_offsets']
+    newtypes = pre_results()['types']['broad_type']
+    assert len(newoff) == 6
+    assert len(newtypes) == 100
+    os.remove("test_preestimation_noprior.hdf5")

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -67,7 +67,6 @@ def test_bpz_train(ntarray, inputdata, groupname, size):
         priormodel = tmpmodel['priormodel']
     for key in expected_keys:
         assert key in priormodel.keys()
-    os.remove("tmp_broad_types.hdf5")
 
 
 def test_output_hdfn_inform():
@@ -94,6 +93,7 @@ def test_output_hdfn_inform():
         priormodel = tmpmodel['priormodel']
     for key in expected_keys:
         assert key in priormodel.keys()
+    os.remove("tmp_broad_types.hdf5")
 
 
 def test_bpz_lite():


### PR DESCRIPTION
Addresses #71 by adding in a "preEstimate" stage to calculate zero point shifts *and* now output the best broad type fits that are needed in the "full" inform stage to compute a new prior (though that should not be run by most people).

Wrote some new tests and linted everything, it all passes and is all covered.

This does require an updated pickle file in rail_base, so the tests will fail until a PR in rail_base is merged.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
