### PR TITLE
fix code to not csat config param to np.array

### DIFF
--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -447,7 +447,6 @@ class BPZliteEstimator(CatEstimator):
                 f"err_bands, {len(self.config.err_bands)} and "
                 f"filter_list {len(self.config.filter_list)} are not the same!"
             )
-        self.config.zp_offsets = np.array(self.config.zp_offsets)
 
     def _initialize_run(self):
         super()._initialize_run()
@@ -544,7 +543,7 @@ class BPZliteEstimator(CatEstimator):
                 detmask = np.isclose(data[bandname], self.config.nondetect_val)
             # Subtract off the zero point offsets
             if self.config.override_file_offsets:
-                zpoff = self.config.zp_offsets
+                zpoff = np.array(self.config.zp_offsets)
             else:
                 zpoff = self.zp_off_from_file
             data[bandname] -= zpoff[ii]


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
