### PR TITLE
update AB file naming with madau

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 
-dependencies = ["desc-bpz", "pz-rail-base>=2.0.0-dev", "qp-prob[full]"]
+dependencies = ["desc-bpz>=0.4.0", "pz-rail-base>=2.0.0-dev", "qp-prob[full]"]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]

--- a/src/rail/estimation/algos/bpz_lite.py
+++ b/src/rail/estimation/algos/bpz_lite.py
@@ -266,8 +266,8 @@ class BPZliteInformer(CatInformer):
             self.m0 = 20.0
             self.nt_array = self.config.nt_array
             if self.config.override_file_offsets:  # pragma: no cover
-                zeropoints =  np.zeros(len(self.config.bands))
-            else: 
+                zeropoints = np.zeros(len(self.config.bands))
+            else:
                 _, _, zeropoints = self._get_broad_type(ngal)
         else:
             self.m0 = self.config.m0
@@ -505,19 +505,23 @@ class BPZliteEstimator(CatEstimator):
 
         for i, s in enumerate(spectra):
             for j, f in enumerate(filters):
-                model = f"{s}.{f}.AB"
+                if self.config.madau_flag == "yes":
+                    mflag = "withmadau"
+                else:
+                    mflag = "nomadau"
+                model = f"{s}.{f}.{mflag}.AB"
                 if model not in ab_file_db:  # pragma: no cover
-                    self._make_new_ab_file(s, f)
+                    self._make_new_ab_file(s, f, mflag)
                 model_path = os.path.join(bpz_ref_data_path, "AB", model)
                 zo, f_mod_0 = get_data(model_path, (0, 1))
                 flux_templates[:, i, j] = match_resol(zo, f_mod_0, z)
 
         return flux_templates
 
-    def _make_new_ab_file(self, spectrum, filter_):  # pragma: no cover
+    def _make_new_ab_file(self, spectrum, filter_, mflag):  # pragma: no cover
         from desc_bpz.bpz_tools_py3 import ABflux
 
-        new_file = f"{spectrum}.{filter_}.AB"
+        new_file = f"{spectrum}.{filter_}.{mflag}.AB"
         self.log.info(f"  Generating new AB file {new_file}....")
         ABflux(spectrum, filter_, self.config.madau_flag)
 

--- a/src/rail/estimation/algos/bpz_preprocess.py
+++ b/src/rail/estimation/algos/bpz_preprocess.py
@@ -188,19 +188,23 @@ class BPZlitePreEstimator(CatEstimator):
 
         for i, s in enumerate(spectra):
             for j, f in enumerate(filters):
-                model = f"{s}.{f}.AB"
+                if self.config.madau_flag == "yes":
+                    mflag = "withmadau"
+                else:
+                    mflag = "nomadau"
+                model = f"{s}.{f}.{mflag}.AB"
                 if model not in ab_file_db:  # pragma: no cover
-                    self._make_new_ab_file(s, f)
+                    self._make_new_ab_file(s, f, mflag)
                 model_path = os.path.join(bpz_ref_data_path, "AB", model)
                 zo, f_mod_0 = get_data(model_path, (0, 1))
                 flux_templates[:, i, j] = match_resol(zo, f_mod_0, z)
 
         return flux_templates
 
-    def _make_new_ab_file(self, spectrum, filter_):  # pragma: no cover
+    def _make_new_ab_file(self, spectrum, filter_, mflag):  # pragma: no cover
         from desc_bpz.bpz_tools_py3 import ABflux
 
-        new_file = f"{spectrum}.{filter_}.AB"
+        new_file = f"{spectrum}.{filter_}.{mflag}.AB"
         self.log.info(f"  Generating new AB file {new_file}....")
         ABflux(spectrum, filter_, self.config.madau_flag)
 

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -149,20 +149,20 @@ def test_bpz_wHDFN_prior(inputdata, groupname):
             RAIL_BPZ_DIR, "rail/examples_data/estimation_data/configs/test_bpz.columns"
         ),
         "spectra_file": "CWWSB4.list",
-        "madau_flag": "no",
         "ref_band": "mag_i_lsst",
         "prior_file": "flat",
         "p_min": 0.005,
         "gauss_kernel": 0.1,
         "zp_errors": np.array([0.01, 0.01, 0.01, 0.01, 0.01, 0.01]),
         "mag_err_min": 0.005,
+        "madau_flag": "yes",
         "hdf5_groupname": groupname,
         "nt_array": [1, 2, 5],
         "model": os.path.join(
             RAILDIR, "rail/examples_data/estimation_data/data/CWW_HDFN_prior.pkl"
         ),
     }
-    zb_expected = np.array([0.18, 2.88, 0.14, 0.19, 2.91, 0.18, 0.21, 0.21, 2.98, 2.92])
+    zb_expected = np.array([0.18, 2.35, 0.14, 0.19, 2.91, 0.18, 0.21, 0.21, 2.94, 2.93])
 
     # validation_data = DS.read_file("validation_data", TableHandle, inputdata)
     validation_data = TableHandle("validation_data", path=inputdata)
@@ -276,6 +276,7 @@ def test_bpz_preestimation_onlytype():
 def test_bpz_preestimation_noprior():
     zp_off = np.zeros(6)
     pre_est_dict = dict(zp_offsets=zp_off,
+                        madau_flag="yes",
                         only_type=True,
                         no_prior=True,
                         output="test_preestimation_noprior.hdf5")


### PR DESCRIPTION
addresses #77 and adds a "withmadau" or "nomadau" to the AB filenames (and adds a requirement in the pyproject.toml since I had to update DESC_BPZ to do this).  This eliminates a potential error where BPZ never bothered to keep track of whether madau was set to yes or no when the AB files were created.  

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
